### PR TITLE
Create CineVerse token

### DIFF
--- a/CineVerse token
+++ b/CineVerse token
@@ -1,0 +1,17 @@
+{
+    "name": "CineVerse Token",
+    "website": "Coming Soon",
+    "description": "CineVerse Token: Empowering Hollywood Creativity, uniting cinema lovers. 20% of tokens go to support SAG and WGA. Join us to fast-track the end of strikes.",
+    "explorer": "https://coinmarketcap.com/dexscan/bsc/0x675129ef876b4d69b7c58c962a060c7bd1c67871",
+    "type": "BEP20",
+    "symbol": "CINE",
+    "decimals": 18,
+    "status": "active",
+    "id": "0x36cFf7C417641e8Ad1835Af7E588C2bAA5338710",
+    "links": {
+        "PancakeSwap": "https://pancakeswap.finance/swap?outputCurrency=0x36cFf7C417641e8Ad1835Af7E588C2bAA5338710",
+        "Telegram": "https://t.me/cineVerse_groupofficial",
+        "Twitter": "https://twitter.com/CineVerseToken/status/1682814165881110532?t=Cpwb98aOTX1eQKgKDkZNrA&s=35"
+    },
+    "logo": "https://i.ibb.co/m8ms8SR/DALL-E-2023-07-18-00-05-45.png"
+}


### PR DESCRIPTION

The CineVerse token is a maneuverable response to the wave of protests by Hollywood screenwriters and actors, which caused an emotional response from many of us. Inspired by the idea of having a direct impact on the film industry, the CineVerse token was created not only as an investment tool, but also as a way to support the Hollywood community in these difficult times.

20% of the total number of CineVerse tokens were deposited in a separate wallet, waiting in the wings for a solemn transfer to the Hollywood screenwriters and actors support fund, which will help speed up the end of the protests and return to normal work.

CineVerse Token encourages movie lovers, TV series enthusiasts and movie fans from all over the world to join our community. Our mission is to create a strong and mutually beneficial community where we can earn together by supporting what we all love - cinema. Join us and be a part of this inspiring journey!